### PR TITLE
Job is exiting when args size is correct

### DIFF
--- a/src/main/scala/thoughtworks/ingest/DailyDriver.scala
+++ b/src/main/scala/thoughtworks/ingest/DailyDriver.scala
@@ -20,7 +20,7 @@ object DailyDriver {
   }
 
   private def getInputAndOutputPaths(args: Array[String]) = {
-    if (args.length == 2) {
+    if (args.length < 2) {
       log.warn("Input source and output path are required")
       System.exit(1)
     }


### PR DESCRIPTION
This job is waiting for two arguments, input and output file. However the job is stopping if the args object has the right number of arguments instead.

I've changed it to stop if the args object size is less than two.